### PR TITLE
Fix notifier list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,12 @@ jobs:
         env:
           MIRIFLAGS: -Zmiri-strict-provenance
 
+      - name: Run cargo miri (ignore leaks)
+        run: cargo miri test --tests
+        env:
+          RUSTFLAGS: --cfg tachyonix_ignore_leaks
+          MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-ignore-leaks
+
   lints:
     name: Lints
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ waker-fn = "1.1"
 [dev-dependencies]
 futures-executor = { version = "0.3", default-features = false, features = ["thread-pool"] }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
-futures-util = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 
 [[test]]
 name = "integration"

--- a/tests/may_leak.rs
+++ b/tests/may_leak.rs
@@ -1,0 +1,74 @@
+use std::mem::{self, ManuallyDrop};
+use std::pin::Pin;
+
+use futures_executor::block_on;
+use futures_util::poll;
+
+use tachyonix::channel;
+
+// Forget a send future, then drop the sender.
+//
+// Mainly meant for MIRI. See <https://github.com/asynchronics/tachyonix/issues/1>.
+#[test]
+fn forget_send_future_drop_sender() {
+    let (s, mut r) = channel(1);
+
+    // Boxing so that MIRI can identify invalidated memory access via use-after-free.
+    let mut s = Box::new(s);
+
+    s.try_send(13).unwrap();
+
+    let mut s_fut = ManuallyDrop::new(s.send(42));
+    let mut s_fut = unsafe { Pin::new_unchecked(&mut *s_fut) }; // safe: the unpinned future is shadowed.
+    assert!(block_on(async { poll!(s_fut.as_mut()) }).is_pending());
+
+    std::mem::forget(s_fut);
+
+    drop(s);
+
+    assert!(r.try_recv().is_ok());
+}
+
+// Forget a send future, then forget the sender.
+//
+// Mainly meant for MIRI. See <https://github.com/asynchronics/tachyonix/issues/1>.
+#[test]
+fn forget_send_future_forget_sender() {
+    let (s, mut r) = channel(1);
+
+    let mut s = ManuallyDrop::new(s);
+    s.try_send(13).unwrap();
+
+    let mut s_fut = ManuallyDrop::new(s.send(42));
+    let mut s_fut = unsafe { Pin::new_unchecked(&mut *s_fut) }; // safe: the unpinned future is shadowed.
+    assert!(block_on(async { poll!(s_fut.as_mut()) }).is_pending());
+
+    mem::forget(s_fut);
+
+    // Forget the sender and move in a new sender.
+    s = ManuallyDrop::new(tachyonix::channel(1).0);
+    let _ = s;
+
+    assert!(r.try_recv().is_ok());
+}
+
+// Forget a send future, then reuse the sender.
+//
+// See <https://github.com/asynchronics/tachyonix/issues/1>.
+#[test]
+fn forget_send_future_reuse_sender() {
+    let (s, mut r) = channel(1);
+
+    let mut s = ManuallyDrop::new(s);
+    s.try_send(7).unwrap();
+
+    let mut s_fut1 = ManuallyDrop::new(s.send(13));
+    let mut s_fut1 = unsafe { Pin::new_unchecked(&mut *s_fut1) }; // safe: the unpinned future is shadowed.
+    assert!(block_on(async { poll!(s_fut1.as_mut()) }).is_pending());
+
+    mem::forget(s_fut1);
+
+    assert!(block_on(async { poll!(Box::pin(s.send(42))) }).is_pending());
+
+    assert!(r.try_recv().is_ok());
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,2 +1,8 @@
-#[cfg(not(tachyonix_loom))]
+/// Non-Loom tests that may not leak memory; on MIRI, enabled only if
+/// `tachyonix_ignore_leaks` is not configured.
+#[cfg(all(not(tachyonix_loom), any(not(miri), not(tachyonix_ignore_leaks))))]
 mod general;
+/// Non-Loom tests that may leak memory; on MIRI, enabled only if
+/// `tachyonix_ignore_leaks` is configured.
+#[cfg(all(not(tachyonix_loom), any(not(miri), tachyonix_ignore_leaks)))]
+mod may_leak;


### PR DESCRIPTION
So this is my 3rd rewrite of a fix for issue #1. Hopefully 3rd time is the charm...

### What I tried

#### First attempt
I initially tried the approach which I suggested at the bottom of the issue: box the notifiers and make `Sender` ensure that the notifier is no longer in the list before it is deallocated. While I believe this was a valid approach, it made the `WaitUntil` future an unsafe leaky abstraction and made it necessary to mark pretty much everything around it as `unsafe`, making the code ugly and brittle.

#### Second attempt
I then decided to take advantage of structural pinning in the `WaitUntil` future and store the notifier inline, which is I guess the approach hinted at by @Darksonn. It looked great since no allocation was needed, and I even figured I could still cache the waker with an approach similar to what I use in this PR. The problem is the cognitive load necessary to make this sound and keep it sound as the code evolves. A good reading on this topic is Sabrina Jewson's [pinned-aliasable](https://github.com/SabrinaJewson/pinned-aliasable.rs) crate and her ultimate tour-de-force, the [pin-list](https://github.com/SabrinaJewson/pin-list.rs) crate.

#### Third attempt
After this sobering dive into pin-based intrusive lists, I decided to keep things simple and use the tried-and-true approach to intrusive list, using only boxed notifiers but this time passing them by value so that the `WaitUntil` future owns the boxed notifier until it is removed from the intrusive list (or forever if forgotten). On future completion, the boxed notifier returns by value to the sender to be cached with its waker, so the notifier is only ever boxed once unless the previous send was not polled to completion.

### What now?

I will leave this PR sit here a couple of days in case anyone was willing to review it (many thanks in advance if anyone does!), and to give myself a little more time to think about it.

The only interesting files to review are `lib.rs` and `event.rs` (second commit). The others changes only relates to adding new tests that would catch this issue. They made the diff bigger than I'd like because I had to segregate tests that can legitimately leak memory and must run with `-Zmiri-ignore-leaks`.

### What after

After this is merged, I will proceed with a small commit adding inlining hints, because for some reason this fix throws off rustc a little and impacts performance even though it shouldn't, but I have identified the culprit and this can be easily repaired.