### PR TITLE
Always allocate notifiers for blocked senders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ?.?.? (????-??-??)
 
+- Improve performance by always allocating new notifiers for blocked senders;
+  this also makes it now possible take `self` by reference in senders.
+- Fix soundness issue when sender is forgotten ([#2])
+
+[#2]: https://github.com/asynchronics/tachyonix/pull/2
+
 
 # 0.1.1 (2022-10-16)
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ which:
   empty-queue events (the latter is courtesy of
   [diatomic-waker][diatomic-waker], a fast, spinlock-free alternative to
   `atomic-waker`),
-- **no allocation** once the senders are created, even for blocked sender/receiver
-  notifications,
+- **no allocation** except for blocked sender notifications,
 - **no spinlocks** whatsoever, and no mutex in the hot path (the only mutex is a
   `std::sync::mutex` used for blocked senders notifications),
 - underlying queue **optimized for single receiver**.
@@ -56,7 +55,7 @@ use futures_executor::{block_on, ThreadPool};
 
 let pool = ThreadPool::new().unwrap();
 
-let (mut s, mut r) = tachyonix::channel(3);
+let (s, mut r) = tachyonix::channel(3);
 
 block_on( async move {
     pool.spawn_ok( async move {
@@ -93,8 +92,6 @@ be acceptable depending on your use-case:
   application, you should use `futures`'s channels.
 * just like most other async channel with the exception of `flume`, its
   low-level primitives rely on `unsafe` (see [dedicated section](#safety)),
-* just like the bounded channels in the `futures` crate but unlike most other
-  channels, sending requires mutable access to a `Sender`,
 * zero-capacity channels (a.k.a. rendez-vous channels) are not supported.
 
 

--- a/src/loom_exports.rs
+++ b/src/loom_exports.rs
@@ -4,7 +4,7 @@ pub(crate) mod sync {
     pub(crate) use loom::sync::{Arc, Mutex};
 
     pub(crate) mod atomic {
-        pub(crate) use loom::sync::atomic::{fence, AtomicBool, AtomicPtr, AtomicUsize};
+        pub(crate) use loom::sync::atomic::{fence, AtomicBool, AtomicUsize};
     }
 }
 #[cfg(not(tachyonix_loom))]
@@ -13,7 +13,7 @@ pub(crate) mod sync {
     pub(crate) use std::sync::{Arc, Mutex};
 
     pub(crate) mod atomic {
-        pub(crate) use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize};
+        pub(crate) use std::sync::atomic::{AtomicBool, AtomicUsize};
 
         #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), not(miri)))]
         #[inline(always)]

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -41,7 +41,7 @@ fn poll_once_and_keep_alive<F: Future>(f: F, millis: u64) -> Poll<F::Output> {
 #[cfg(not(miri))]
 #[test]
 fn try_send_recv() {
-    let (mut s, mut r) = channel(2);
+    let (s, mut r) = channel(2);
 
     let th_send = thread::spawn(move || {
         sleep(100);
@@ -67,7 +67,7 @@ fn try_send_recv() {
 #[cfg(not(miri))]
 #[test]
 fn async_send() {
-    let (mut s, mut r) = channel(2);
+    let (s, mut r) = channel(2);
 
     let th_send = thread::spawn(move || {
         block_on(s.send(3)).unwrap();
@@ -92,7 +92,7 @@ fn async_send() {
 #[cfg(not(miri))]
 #[test]
 fn async_recv() {
-    let (mut s, mut r) = channel(100);
+    let (s, mut r) = channel(100);
 
     let th_send = thread::spawn(move || {
         sleep(100);
@@ -114,7 +114,7 @@ fn async_recv() {
 // Channel closed due to the receiver being dropped.
 #[test]
 fn send_after_close() {
-    let (mut s, r) = channel(100);
+    let (s, r) = channel(100);
 
     block_on(s.send(3)).unwrap();
     block_on(s.send(7)).unwrap();
@@ -130,8 +130,8 @@ fn send_after_close() {
 #[cfg(not(miri))]
 #[test]
 fn blocked_send_after_close() {
-    let (mut s1, r) = channel(2);
-    let mut s2 = s1.clone();
+    let (s1, r) = channel(2);
+    let s2 = s1.clone();
 
     block_on(s1.send(3)).unwrap();
     block_on(s1.send(7)).unwrap();
@@ -153,8 +153,8 @@ fn blocked_send_after_close() {
 // Channel closed due to the senders being dropped.
 #[test]
 fn recv_after_close() {
-    let (mut s1, mut r) = channel(100);
-    let mut s2 = s1.clone();
+    let (s1, mut r) = channel(100);
+    let s2 = s1.clone();
 
     block_on(s1.send(3)).unwrap();
     block_on(s1.send(7)).unwrap();
@@ -175,8 +175,8 @@ fn recv_after_close() {
 #[cfg(not(miri))]
 #[test]
 fn blocked_recv_after_close() {
-    let (mut s1, mut r) = channel(100);
-    let mut s2 = s1.clone();
+    let (s1, mut r) = channel(100);
+    let s2 = s1.clone();
 
     block_on(s1.send(3)).unwrap();
     block_on(s1.send(7)).unwrap();
@@ -202,8 +202,8 @@ fn blocked_recv_after_close() {
 #[cfg(not(miri))]
 #[test]
 fn cancel_async_send() {
-    let (mut s1, mut r) = channel(2);
-    let mut s2 = s1.clone();
+    let (s1, mut r) = channel(2);
+    let s2 = s1.clone();
 
     // Fill the channel and block a sender, then cancel the sending operation at
     // t0 + 300.
@@ -240,8 +240,8 @@ fn cancel_async_send() {
 #[cfg(not(miri))]
 #[test]
 fn forget_async_send() {
-    let (mut s1, mut r) = channel(2);
-    let mut s2 = s1.clone();
+    let (s1, mut r) = channel(2);
+    let s2 = s1.clone();
 
     // Fill the channel and block a sender, then stop polling it for a long
     // time.
@@ -280,7 +280,7 @@ fn spsc_stress() {
     const CAPACITY: usize = 3;
     const COUNT: usize = if cfg!(miri) { 50 } else { 1_000_000 };
 
-    let (mut s, mut r) = channel(CAPACITY);
+    let (s, mut r) = channel(CAPACITY);
 
     let th_send = thread::spawn(move || {
         block_on(async {
@@ -313,7 +313,7 @@ fn mpsc_stress() {
     let (s, mut r) = channel(CAPACITY);
 
     let th_send = (0..THREADS).map(|_| {
-        let mut s = s.clone();
+        let s = s.clone();
 
         thread::spawn(move || {
             block_on(async {

--- a/tests/may_leak.rs
+++ b/tests/may_leak.rs
@@ -14,7 +14,7 @@ fn forget_send_future_drop_sender() {
     let (s, mut r) = channel(1);
 
     // Boxing so that MIRI can identify invalidated memory access via use-after-free.
-    let mut s = Box::new(s);
+    let s = Box::new(s);
 
     s.try_send(13).unwrap();
 
@@ -59,7 +59,7 @@ fn forget_send_future_forget_sender() {
 fn forget_send_future_reuse_sender() {
     let (s, mut r) = channel(1);
 
-    let mut s = ManuallyDrop::new(s);
+    let s = ManuallyDrop::new(s);
     s.try_send(7).unwrap();
 
     let mut s_fut1 = ManuallyDrop::new(s.send(13));


### PR DESCRIPTION
Previous versions of tachyonix would cache the notifiers and their associated waker in the sender. While in theory this spares both on allocation and waker cloning, it appears to prevent some optimizations and actually results in worse performance across nearly all benchmarks and benchmark parameters.

So this is a "worse" version which appears to perform better and makes it possible to have the sender take `self` by shared reference rather than by mutable reference.

Also, this commit removes the `UnsafeCell` around the waker, which was there only to enable tracking through loom but which turned out to have a non-negligible impact on performance.